### PR TITLE
Detect existing signs on chunk load

### DIFF
--- a/bukkit/src/main/java/io/wdsj/asw/bukkit/service/ListenerService.java
+++ b/bukkit/src/main/java/io/wdsj/asw/bukkit/service/ListenerService.java
@@ -6,6 +6,7 @@ import io.wdsj.asw.bukkit.annotation.PaperEventHandler;
 import io.wdsj.asw.bukkit.listener.*;
 import io.wdsj.asw.bukkit.listener.packet.ASWBookPacketListener;
 import io.wdsj.asw.bukkit.listener.packet.ASWChatPacketListener;
+import io.wdsj.asw.bukkit.listener.paper.PaperChunkLoadListener;
 import io.wdsj.asw.bukkit.listener.paper.PaperFakeMessageExecutor;
 import io.wdsj.asw.bukkit.listener.paper.PaperItemSpawnListener;
 import io.wdsj.asw.bukkit.setting.PluginSettings;
@@ -88,6 +89,7 @@ public class ListenerService {
         if (settingsManager.getProperty(PluginSettings.CHECK_FOR_UPDATE)) {
             registerEventListener(JoinUpdateNotifier.class);
         }
+        registerEventListener(PaperChunkLoadListener.class);
     }
 
     public void unregisterListeners() {

--- a/bukkit/src/main/kotlin/io/wdsj/asw/bukkit/listener/paper/PaperChunkLoadListener.kt
+++ b/bukkit/src/main/kotlin/io/wdsj/asw/bukkit/listener/paper/PaperChunkLoadListener.kt
@@ -43,6 +43,7 @@ class PaperChunkLoadListener : Listener {
                         val block = event.chunk.getBlock(triple.first, triple.second, triple.third)
                         LOGGER.info("Sign at (${triple.first}, ${triple.second}, ${triple.third}), ${block.state}")
                         val state = block.state
+                        // TODO: Implement actual logic here
                         LOGGER.info(state.toString())
                         if (state is Sign) {
                             val lines = state.getSide(Side.FRONT)

--- a/bukkit/src/main/kotlin/io/wdsj/asw/bukkit/listener/paper/PaperChunkLoadListener.kt
+++ b/bukkit/src/main/kotlin/io/wdsj/asw/bukkit/listener/paper/PaperChunkLoadListener.kt
@@ -21,7 +21,7 @@ class PaperChunkLoadListener : Listener {
         val potentialSignPositions = ArrayList<Triple<Int, Int, Int>>()
         val minY = event.chunk.world.minHeight
         val maxY = event.chunk.world.maxHeight
-        CompletableFuture.runAsync({
+        CompletableFuture.supplyAsync({
             for (x in 0 until 16) {
                 for (z in 0 until 16) {
                     for (y in minY until maxY) {
@@ -33,7 +33,6 @@ class PaperChunkLoadListener : Listener {
                     }
                 }
             }
-
         }, Utils.commonWorker)
             .thenRun {
                 if (potentialSignPositions.isNotEmpty()) {
@@ -42,7 +41,9 @@ class PaperChunkLoadListener : Listener {
                     LOGGER.warning("Signs found at: $potentialSignPositions")
                     for (triple in potentialSignPositions) {
                         val block = event.chunk.getBlock(triple.first, triple.second, triple.third)
+                        LOGGER.info("Sign at (${triple.first}, ${triple.second}, ${triple.third}), ${block.state}")
                         val state = block.state
+                        LOGGER.info(state.toString())
                         if (state is Sign) {
                             val lines = state.getSide(Side.FRONT)
 

--- a/bukkit/src/main/kotlin/io/wdsj/asw/bukkit/listener/paper/PaperChunkLoadListener.kt
+++ b/bukkit/src/main/kotlin/io/wdsj/asw/bukkit/listener/paper/PaperChunkLoadListener.kt
@@ -1,0 +1,55 @@
+package io.wdsj.asw.bukkit.listener.paper
+
+import io.wdsj.asw.bukkit.AdvancedSensitiveWords.LOGGER
+import io.wdsj.asw.bukkit.annotation.PaperEventHandler
+import io.wdsj.asw.bukkit.util.Utils
+import org.bukkit.block.Sign
+import org.bukkit.block.sign.Side
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.world.ChunkLoadEvent
+import java.util.concurrent.CompletableFuture
+
+@PaperEventHandler
+class PaperChunkLoadListener : Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onChunkLoad(event: ChunkLoadEvent) {
+        val snapshot = event.chunk.chunkSnapshot
+
+        val potentialSignPositions = ArrayList<Triple<Int, Int, Int>>()
+        val minY = event.chunk.world.minHeight
+        val maxY = event.chunk.world.maxHeight
+        CompletableFuture.runAsync({
+            for (x in 0 until 16) {
+                for (z in 0 until 16) {
+                    for (y in minY until maxY) {
+                        val blockData = snapshot.getBlockData(x, y, z)
+
+                        if (blockData.material.toString().contains("SIGN", true)) {
+                            potentialSignPositions.add(Triple(x, y, z))
+                        }
+                    }
+                }
+            }
+
+        }, Utils.commonWorker)
+            .thenRun {
+                if (potentialSignPositions.isNotEmpty()) {
+                    LOGGER.warning("Found signs in chunk ${event.chunk.x}, ${event.chunk.z}")
+                    LOGGER.warning("Signs found: ${potentialSignPositions.size}")
+                    LOGGER.warning("Signs found at: $potentialSignPositions")
+                    for (triple in potentialSignPositions) {
+                        val block = event.chunk.getBlock(triple.first, triple.second, triple.third)
+                        val state = block.state
+                        if (state is Sign) {
+                            val lines = state.getSide(Side.FRONT)
+
+                            LOGGER.info("Sign at (${triple.first}, ${triple.second}, ${triple.third}) contains: $lines")
+                        }
+                    }
+                }
+            }
+    }
+}

--- a/bukkit/src/main/kotlin/io/wdsj/asw/bukkit/util/Utils.kt
+++ b/bukkit/src/main/kotlin/io/wdsj/asw/bukkit/util/Utils.kt
@@ -1,16 +1,26 @@
 package io.wdsj.asw.bukkit.util
 
 import com.github.houbb.heaven.util.lang.StringUtil
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import io.wdsj.asw.bukkit.AdvancedSensitiveWords
 import io.wdsj.asw.bukkit.setting.PluginSettings
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import java.util.*
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 
 object Utils {
     @JvmField
     val messagesFilteredNum: AtomicLong = AtomicLong(0)
+
+    val commonWorker: ExecutorService = Executors.newCachedThreadPool(
+        ThreadFactoryBuilder()
+            .setNameFormat("ASW Common Worker-%d")
+            .setPriority(Thread.NORM_PRIORITY - 1)
+            .build()
+    )
 
     @JvmStatic
     fun getPlayerIp(player: Player): String {


### PR DESCRIPTION
This pull request attempts to scan chunks on load for sign content detection asynchronously without performance impact.

TODOs:
- [ ] Finish basic sign scan
- [ ] Add actual replace logic
- [ ] Performance improvement