### PR TITLE
添加enable-sign-fake-view选项

### DIFF
--- a/paper/src/main/java/io/wdsj/asw/bukkit/integration/packetevents/sign/SignFakeViewCompat.java
+++ b/paper/src/main/java/io/wdsj/asw/bukkit/integration/packetevents/sign/SignFakeViewCompat.java
@@ -21,6 +21,11 @@ public final class SignFakeViewCompat {
         if (!AdvancedSensitiveWords.setting(PluginSettings.ENABLE_SIGN_EDIT_CHECK)) {
             return;
         }
+        // Master toggle for the whole fake-view subsystem (packet listener + writes + refresh).
+        // Disabled here means the packet listener is never registered, so no per-sign scanning cost.
+        if (!AdvancedSensitiveWords.setting(PluginSettings.SIGN_ENABLE_FAKE_VIEW)) {
+            return;
+        }
 
         if (!isPacketEventsAvailable()) {
             logPacketEventsUnavailable();

--- a/paper/src/main/java/io/wdsj/asw/bukkit/setting/PluginSettings.java
+++ b/paper/src/main/java/io/wdsj/asw/bukkit/setting/PluginSettings.java
@@ -118,6 +118,7 @@ public final class PluginSettings {
 
     public static final SettingKey<ProcessMethod> SIGN_METHOD = key(settings -> settings.sign.method);
     public static final SettingKey<Boolean> SIGN_FAKE_ON_CANCEL = key(settings -> settings.sign.fakeOnCancel);
+    public static final SettingKey<Boolean> SIGN_ENABLE_FAKE_VIEW = key(settings -> settings.sign.enableSignFakeView);
     public static final SettingKey<List<String>> SIGN_PUNISHMENT = key(settings -> settings.sign.punishment);
     public static final SettingKey<Boolean> SIGN_MULTI_LINE_CHECK = key(settings -> settings.sign.multiLineCheck);
     public static final SettingKey<Boolean> SIGN_CONTEXT_CHECK = key(settings -> settings.sign.contextCheck);

--- a/paper/src/main/java/io/wdsj/asw/bukkit/setting/SettingsConfiguration.java
+++ b/paper/src/main/java/io/wdsj/asw/bukkit/setting/SettingsConfiguration.java
@@ -353,6 +353,15 @@ public final class SettingsConfiguration {
         public ProcessMethod method = ProcessMethod.REPLACE;
         @Comment("Whether cancelled edits should be shown only to their author through PacketEvents.")
         public boolean fakeOnCancel = false;
+        @Comment({
+            "Master toggle for the PacketEvents-based sign fake-view subsystem.",
+            "When enabled, cancelled/shadowed edits are shown to their author while others see blank;",
+            "this requires scanning every sign tile entity the client receives (chunk loads and block-entity",
+            "update packets), which adds a per-sign block-state snapshot cost on the server thread.",
+            "Disable this to avoid the extra overhead if you do not need the fake-view behaviour.",
+            "Has no effect unless 'enableSignEditCheck' is true and PacketEvents is present."
+        })
+        public boolean enableSignFakeView = true;
         @Comment("Punishment actions for sign violations. Leave empty to disable automatic punishment.")
         public List<String> punishment = new ArrayList<>();
         @Comment("Whether to check words split across sign lines.")


### PR DESCRIPTION
添加enable-sign-fake-view开关选项使其修复部分性能占用问题
(因为该功能对于从刚开服就已经安装着ASW插件的服务器是无效的，所有告示牌都没有违禁词)
<img width="944" height="696" alt="image" src="https://github.com/user-attachments/assets/9c9d1840-698f-44d6-acfa-ac650218dfc8" />